### PR TITLE
Manage choice of nginx package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ Configures Nginx's [`log_format`](http://nginx.org/en/docs/http/ngx_http_log_mod
 
 (For RedHat/CentOS only) Set this to `false` to disable the installation of the `nginx` yum repository. This could be necessary if you want the default OS stable packages, or if you use Satellite.
 
+    nginx_package_name: "nginx"
+    nginx_package_version: "1.12.0-1"
+
+(For Debian only) The name and version of the package to install.
+Version format must be: MAJOR.MINOR.REVISION-BUILDNUMBER
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ nginx_ppa_version: stable
 
 # The name of the nginx apt/yum package to install.
 nginx_package_name: "nginx"
+nginx_package_version: "1.12.1-1"
 
 nginx_worker_processes: "{{ ansible_processor_vcpus | default(ansible_processor_count) }}"
 nginx_worker_connections: "1024"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Ensure nginx apt repository is present
   apt_repository:
-    repo: deb http://nginx.org/packages/debian/ jessie nginx
+    repo: "deb http://nginx.org/packages/debian/ {{ ansible_distribution_release }} nginx"
     state: present
     filename: nginx
     update_cache: yes

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,6 +5,6 @@
 
 - name: Ensure nginx is installed.
   apt:
-    name: "{{ nginx_package_name }}"
+    name: "{{ nginx_package_name }}={{ nginx_package_version }}~{{ ansible_distribution_release }}"
     state: installed
     default_release: "{{ nginx_default_release }}"


### PR DESCRIPTION
In order to uniformize nginx version on all env, we need to be able to choose the version in the role